### PR TITLE
Changed GitHub information in config/deploy.rb

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -70,9 +70,9 @@ task :staging do
 
   role :rvm, "web-1.fr2.ec2.internal", "sphinx.fr2.ec2.internal", "worker.fr2.ec2.internal", "proxy.fr2.ec2.internal"
 
-  set :github_user_repo, 'criticaljuncture'
+  set :github_user_repo, 'usnationalarchives'
   set :github_project_repo, 'federalregister-web'
-  set :github_username, 'criticaljuncture'
+  set :github_username, 'usnationalarchives'
   set :repository, "git@github.com:#{github_user_repo}/#{github_project_repo}.git"
 end
 

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -46,11 +46,9 @@ task :production do
 
   role :rvm, "web-1.fr2.ec2.internal", "web-2.fr2.ec2.internal", "web-3.fr2.ec2.internal", "web-4.fr2.ec2.internal", "web-5.fr2.ec2.internal", "sphinx.fr2.ec2.internal", "worker.fr2.ec2.internal", "proxy.fr2.ec2.internal"
 
-  #set :github_user_repo, 'usnationalarchives'
-  set :github_user_repo, 'criticaljuncture'
+  set :github_user_repo, 'usnationalarchives'
   set :github_project_repo, 'federalregister-web'
-  #set :github_username, 'usnationalarchives'
-  set :github_username, 'criticaljuncture'
+  set :github_username, 'usnationalarchives'
   set :repository, "git@github.com:#{github_user_repo}/#{github_project_repo}.git"
 end
 


### PR DESCRIPTION
I identified this while looking at https://www.federalregister.gov/reader-aids/developer-resources/rest-api which hosts a link to https://github.com/criticaljuncture/federal_register which does not exist anymore. I'm not confident this change will fix that link; however, I wanted to flag that here as well.